### PR TITLE
Feature 100mm straight middle interface in lg

### DIFF
--- a/include/MOLLEROptDetector.hh
+++ b/include/MOLLEROptDetector.hh
@@ -21,6 +21,7 @@ struct DesignParameters{
   G4double QuartzSizeZ;
   
   G4double LowerInterfacePlane;
+  G4double MiddleBoxHeight;
   G4double UpperInterfacePlane;
   G4double LowerConeFrontFaceAngle;
   G4double LowerConeBackFaceAngle;
@@ -71,6 +72,7 @@ public:
   void SetLightGuideOffsetInZ(G4double z);
   
   void SetLowerInterfacePlane(G4double LowerPlane);
+  void SetMiddleBoxHeight(G4double MiddlePlane);
   void SetUpperInterfacePlane(G4double UpperPlane);
   void SetLowerConeFrontFaceAngle(G4double angle) ; //in radians
   void SetLowerConeBackFaceAngle(G4double angle);

--- a/include/MOLLEROptDetectorLightGuide.hh
+++ b/include/MOLLEROptDetectorLightGuide.hh
@@ -49,7 +49,7 @@ public:
   void SetPMTOpeningRadius(G4double val)          {PMTOpeningRadius = val;};
 
   G4double GetCurrentLowerInterfacePlane()     {return LowerInterfacePlane;};
-  G4double GetMiddleBoxHeight()     {return MiddleBoxHeight;};
+  G4double GetCurrentMiddleBoxHeight()         {return MiddleBoxHeight;};
   G4double GetCurrentUpperInterfacePlane()     {return UpperInterfacePlane;};
   G4double GetCurrentLowerConeFrontFaceAngle() {return LowerConeFrontFaceAngle;};
   G4double GetCurrentLowerConeBackFaceAngle()  {return LowerConeBackFaceAngle;};

--- a/include/MOLLEROptDetectorLightGuide.hh
+++ b/include/MOLLEROptDetectorLightGuide.hh
@@ -33,6 +33,7 @@ public:
 
 
   void SetLowerInterfacePlane(G4double LowerPlane){LowerInterfacePlane = LowerPlane;};
+  void SetMiddleBoxHeight(G4double MiddlePlane){MiddleBoxHeight = MiddlePlane;};
   void SetUpperInterfacePlane(G4double UpperPlane){UpperInterfacePlane = UpperPlane; GuideTotalLength = UpperPlane;};
   void SetLowerConeFrontFaceAngle(G4double angle) {LowerConeFrontFaceAngle = angle;};
   void SetLowerConeBackFaceAngle(G4double angle)  {LowerConeBackFaceAngle = angle;};
@@ -48,6 +49,7 @@ public:
   void SetPMTOpeningRadius(G4double val)          {PMTOpeningRadius = val;};
 
   G4double GetCurrentLowerInterfacePlane()     {return LowerInterfacePlane;};
+  G4double GetMiddleBoxHeight()     {return MiddleBoxHeight;};
   G4double GetCurrentUpperInterfacePlane()     {return UpperInterfacePlane;};
   G4double GetCurrentLowerConeFrontFaceAngle() {return LowerConeFrontFaceAngle;};
   G4double GetCurrentLowerConeBackFaceAngle()  {return LowerConeBackFaceAngle;};
@@ -153,6 +155,7 @@ private:
   G4ThreeVector UpperConeTop[5];
 
   G4double LowerInterfacePlane; //See function SetInterfacePlanes(..) for explanation 
+  G4double MiddleBoxHeight;     // Straight Middle Section
   G4double UpperInterfacePlane;
 
   G4double LowerConeFrontFaceAngle; //Front meaning beam upstream and the angle (theta)

--- a/include/MOLLEROptDetectorLightGuide.hh
+++ b/include/MOLLEROptDetectorLightGuide.hh
@@ -89,6 +89,11 @@ private:
   MOLLEROptMaterial*  Materials;
 
   G4VPhysicalVolume* Mother;
+  
+  G4Box*              GuideMiddleBoxSolid; 
+  G4Box*              GuideMiddleBoxSolid_out; 
+  G4UnionSolid*	      IntermediateInnerSolid; 
+  G4UnionSolid*	      IntermediateOuterSolid; 
 
   G4Tubs*            GuideTopCutoutSolid;
   G4Box*             GuideTopBoxSolid;

--- a/include/MOLLEROptDetectorLightGuide.hh
+++ b/include/MOLLEROptDetectorLightGuide.hh
@@ -147,6 +147,12 @@ private:
   G4ThreeVector LowerConeBack[5];
   G4ThreeVector LowerConeSide1[5];
   G4ThreeVector LowerConeSide2[5];
+  
+  G4ThreeVector MiddleBoxBottom[5];
+  G4ThreeVector MiddleBoxFront[5];
+  G4ThreeVector MiddleBoxBack[5];
+  G4ThreeVector MiddleBoxSide1[5];
+  G4ThreeVector MiddleBoxSide2[5];
          
   G4ThreeVector UpperConeFront[5];
   G4ThreeVector UpperConeBack[5];

--- a/include/MOLLEROptDetectorMessenger.hh
+++ b/include/MOLLEROptDetectorMessenger.hh
@@ -28,6 +28,7 @@ private:
   G4UIcmdWithADoubleAndUnit* DetZPositionCmd;
 
   G4UIcmdWithADoubleAndUnit* LightGuideUpperInterfaceCmd;
+  G4UIcmdWithADoubleAndUnit* LightGuideMiddleBoxCmd;
   G4UIcmdWithADoubleAndUnit* LightGuideLowerInterfaceCmd;
   G4UIcmdWithADoubleAndUnit* LightGuideLowerConeFrontAngleCmd;
   G4UIcmdWithADoubleAndUnit* LightGuideLowerConeBackAngleCmd;

--- a/src/MOLLEROptDetector.cc
+++ b/src/MOLLEROptDetector.cc
@@ -94,6 +94,14 @@ void MOLLEROptDetector::SetLowerInterfacePlane(G4double LowerPlane)
   DesignParms->LowerInterfacePlane = LowerPlane;
 }
 
+void MOLLEROptDetector::SetMiddleBoxHeight(G4double MiddlePlane)
+{
+  if(LightGuide)
+    LightGuide->SetMiddleBoxHeight(MiddlePlane);
+
+  DesignParms->MiddleBoxHeight = MiddlePlane;
+}
+
 void MOLLEROptDetector::SetUpperInterfacePlane(G4double UpperPlane)
 {
   if(LightGuide)
@@ -244,7 +252,7 @@ void MOLLEROptDetector::CalculateDimensions()
   else
     DetFullLengthZ = 2*PMT->GetRadius() + 2*PMTToQuartzOffset + 4.0*cm;
   
-  DetFullLengthY = Quartz->GetQuartzSizeY()+LightGuide->GetLightGuideLength()+PMT->GetPMTLength()+1.0*cm;
+  DetFullLengthY = Quartz->GetQuartzSizeY()+LightGuide->GetLightGuideLength()+PMT->GetPMTLength()+1.0*cm+LightGuide->GetCurrentMiddleBoxHeight();
 }
 
 void MOLLEROptDetector::ResetCenterLocation()
@@ -317,7 +325,7 @@ G4VPhysicalVolume* MOLLEROptDetector::ConstructDetector(G4VPhysicalVolume* Mothe
   LightGuide->SetCenterPositionInY(-0.5*DetFullLengthY+quartzY + 5*mm);// + 0.5*LightGuide->GetCurrentQuartzInterfaceOpeningY()*TMath::Sin(Qrot));
   PMT->Construct(DetPhysical);
   // We have to let the PMT extend into the light guide lsig
-  PMT->SetCenterPositionInY(-0.5*DetFullLengthY+quartzY+lguideY+PMT->GetPMTLength()/2.0 + 5.0*mm);// + 0.5*LightGuide->GetCurrentQuartzInterfaceOpeningY()*TMath::Sin(Qrot));
+  PMT->SetCenterPositionInY(-0.5*DetFullLengthY+quartzY+lguideY+PMT->GetPMTLength()/2.0 + 5.0*mm+LightGuide->GetCurrentMiddleBoxHeight());// + 0.5*LightGuide->GetCurrentQuartzInterfaceOpeningY()*TMath::Sin(Qrot));
 
   G4Colour  grey      ( 127/255., 127/255., 127/255.);
   G4VisAttributes *att = new G4VisAttributes(grey);

--- a/src/MOLLEROptDetectorLightGuide.cc
+++ b/src/MOLLEROptDetectorLightGuide.cc
@@ -462,6 +462,14 @@ void MOLLEROptDetectorLightGuide::ExportGeometrySTL()
   WriteSTLFacet(&LowerConeBack[2]);
   WriteSTLFacet(LowerConeSide2);
   WriteSTLFacet(&LowerConeSide2[2]);
+  WriteSTLFacet(MiddleBoxFront);
+  WriteSTLFacet(&MiddleBoxFront[2]);
+  WriteSTLFacet(MiddleBoxSide1);
+  WriteSTLFacet(&MiddleBoxSide1[2]);
+  WriteSTLFacet(MiddleBoxBack);
+  WriteSTLFacet(&MiddleBoxBack[2]);
+  WriteSTLFacet(MiddleBoxSide2);
+  WriteSTLFacet(&MiddleBoxSide2[2]);	
   WriteSTLFacet(UpperConeFront);
   WriteSTLFacet(&UpperConeFront[2]);
   WriteSTLFacet(UpperConeBack);

--- a/src/MOLLEROptDetectorLightGuide.cc
+++ b/src/MOLLEROptDetectorLightGuide.cc
@@ -44,7 +44,7 @@ MOLLEROptDetectorLightGuide::MOLLEROptDetectorLightGuide(MOLLEROptTrackingReadou
   thisName = name+"_LG";
 
   LowerInterfacePlane     = 5.6*cm;
-  MiddleBoxHeight         = 10.0*cm
+  MiddleBoxHeight         = 10.0*cm;
   UpperInterfacePlane     = 25.0*cm;
   LowerConeFrontFaceAngle = 28*TMath::Pi()/180*rad;                            
   LowerConeBackFaceAngle  =  22*TMath::Pi()/180*rad;
@@ -273,7 +273,7 @@ void MOLLEROptDetectorLightGuide::DefineGeometry()
   UpperConeVertices[6] = G4TwoVector(-PMTInterfaceOpeningX/2,PMTInterfaceOpeningZ/2-QuartzToPMTOffsetInZ);
   UpperConeVertices[7] = G4TwoVector(PMTInterfaceOpeningX/2,PMTInterfaceOpeningZ/2-QuartzToPMTOffsetInZ);  
 
-  G4Box *GuideMiddleBoxSolid = new G4Box(thisName+"_InnerSolid",LowerIP_x,(LowerIP_py-LowerIP_ny)/2,MiddleBoxHeight/2);
+  G4Box *GuideMiddleBoxSolid = new G4Box(thisName+"_InnerSolid",LowerIP_x,(LowerIP_pz-LowerIP_nz)/2,MiddleBoxHeight/2);
   
   //now do the outer surface ******************************************************************************************************
 
@@ -301,7 +301,7 @@ void MOLLEROptDetectorLightGuide::DefineGeometry()
   UpperConeVertices_out[6] = G4TwoVector(-(PMTInterfaceOpeningX+2.0*mm)/2,(PMTInterfaceOpeningZ+2.0*mm)/2-QuartzToPMTOffsetInZ);
   UpperConeVertices_out[7] = G4TwoVector((PMTInterfaceOpeningX+2.0*mm)/2,(PMTInterfaceOpeningZ+2.0*mm)/2-QuartzToPMTOffsetInZ);
 	
-  G4Box *GuideMiddleBoxSolid = new G4Box(thisName+"_InnerSolid",LowerIP_x,(LowerIP_py-LowerIP_ny)/2,MiddleBoxHeight/2);	
+  G4Box *GuideMiddleBoxSolid = new G4Box(thisName+"_InnerSolid",LowerIP_x,(LowerIP_pz-LowerIP_nz)/2,MiddleBoxHeight/2);	
 
   //******************************************************************************************************************************
 

--- a/src/MOLLEROptDetectorLightGuide.cc
+++ b/src/MOLLEROptDetectorLightGuide.cc
@@ -393,37 +393,60 @@ void MOLLEROptDetectorLightGuide::ExportGeometrySTL()
   LowerConeSide2[2].set(-LowerIP_x,LowerInterfacePlane,LowerIP_pz);
   LowerConeSide2[3].set(-LowerIP_x,LowerInterfacePlane,LowerIP_nz);
   LowerConeSide2[4].set(-(QuartzInterfaceOpeningX+2.0*mm)/2,0,-(QuartzInterfaceOpeningZ+2.0*mm)/2);
-
+	
+  MiddleBoxFront[0].set(LowerIP_x,LowerInterfacePlane,LowerIP_nz);
+  MiddleBoxFront[1].set(-LowerIP_x,LowerInterfacePlane,LowerIP_nz);
+  MiddleBoxFront[2].set(-LowerIP_x,LowerInterfacePlane+MiddleBoxHeight,LowerIP_nz);
+  MiddleBoxFront[3].set(LowerIP_x,LowerInterfacePlane+MiddleBoxHeight,LowerIP_nz); 
+  MiddleBoxFront[4].set(LowerIP_x,LowerInterfacePlane,LowerIP_nz);
   
-  UpperConeFront[0].set(LowerIP_x,LowerInterfacePlane,LowerIP_nz);
-  UpperConeFront[1].set(-LowerIP_x,LowerInterfacePlane,LowerIP_nz);
-  UpperConeFront[2].set(-(PMTInterfaceOpeningX+2.0*mm)/2,UpperInterfacePlane,-(PMTInterfaceOpeningZ+2.0*mm)/2-QuartzToPMTOffsetInZ);
-  UpperConeFront[3].set((PMTInterfaceOpeningX+2.0*mm)/2,UpperInterfacePlane,-(PMTInterfaceOpeningZ+2.0*mm)/2-QuartzToPMTOffsetInZ);
-  UpperConeFront[4].set(LowerIP_x,LowerInterfacePlane,LowerIP_nz);
+  MiddleBoxBack[0].set(-LowerIP_x,LowerInterfacePlane,LowerIP_pz);
+  MiddleBoxBack[1].set(LowerIP_x,LowerInterfacePlane,LowerIP_pz); 
+  MiddleBoxBack[2].set(LowerIP_x,LowerInterfacePlane+MiddleBoxHeight,LowerIP_pz);
+  MiddleBoxBack[3].set(-LowerIP_x,LowerInterfacePlane+MiddleBoxHeight,LowerIP_pz);    
+  MiddleBoxBack[4].set(-LowerIP_x,LowerInterfacePlane,LowerIP_pz);
+  
+  MiddleBoxSide1[0].set(LowerIP_x,LowerInterfacePlane,LowerIP_nz);
+  MiddleBoxSide1[1].set(LowerIP_x,LowerInterfacePlane+MiddleBoxHeight,LowerIP_nz);
+  MiddleBoxSide1[2].set(LowerIP_x,LowerInterfacePlane+MiddleBoxHeight,LowerIP_pz);
+  MiddleBoxSide1[3].set(LowerIP_x,LowerInterfacePlane,LowerIP_pz);
+  MiddleBoxSide1[4].set(LowerIP_x,LowerInterfacePlane,LowerIP_nz);
+  
+  MiddleBoxSide2[0].set(-LowerIP_x,LowerInterfacePlane,LowerIP_pz);
+  MiddleBoxSide2[1].set(-LowerIP_x,LowerInterfacePlane+MiddleBoxHeight,LowerIP_pz);
+  MiddleBoxSide2[2].set(-LowerIP_x,LowerInterfacePlane+MiddleBoxHeight,LowerIP_nz);
+  MiddleBoxSide2[3].set(-LowerIP_x,LowerInterfacePlane,LowerIP_nz);
+  MiddleBoxSide2[4].set(-LowerIP_x,LowerInterfacePlane,LowerIP_pz);	
+  
+  UpperConeFront[0].set(LowerIP_x,LowerInterfacePlane+MiddleBoxHeight,LowerIP_nz);
+  UpperConeFront[1].set(-LowerIP_x,LowerInterfacePlane+MiddleBoxHeight,LowerIP_nz);
+  UpperConeFront[2].set(-(PMTInterfaceOpeningX+2.0*mm)/2,UpperInterfacePlane+MiddleBoxHeight,-(PMTInterfaceOpeningZ+2.0*mm)/2-QuartzToPMTOffsetInZ);
+  UpperConeFront[3].set((PMTInterfaceOpeningX+2.0*mm)/2,UpperInterfacePlane+MiddleBoxHeight,-(PMTInterfaceOpeningZ+2.0*mm)/2-QuartzToPMTOffsetInZ);
+  UpperConeFront[4].set(LowerIP_x,LowerInterfacePlane+MiddleBoxHeight,LowerIP_nz);
 
-  UpperConeBack[0].set(-LowerIP_x,LowerInterfacePlane,LowerIP_pz);
-  UpperConeBack[1].set(LowerIP_x,LowerInterfacePlane,LowerIP_pz);
-  UpperConeBack[2].set((PMTInterfaceOpeningX+2.0*mm)/2,UpperInterfacePlane,(PMTInterfaceOpeningZ+2.0*mm)/2-QuartzToPMTOffsetInZ);
-  UpperConeBack[3].set(-(PMTInterfaceOpeningX+2.0*mm)/2,UpperInterfacePlane,(PMTInterfaceOpeningZ+2.0*mm)/2-QuartzToPMTOffsetInZ);
-  UpperConeBack[4].set(-LowerIP_x,LowerInterfacePlane,LowerIP_pz);
+  UpperConeBack[0].set(-LowerIP_x,LowerInterfacePlane+MiddleBoxHeight,LowerIP_pz);
+  UpperConeBack[1].set(LowerIP_x,LowerInterfacePlane+MiddleBoxHeight,LowerIP_pz);
+  UpperConeBack[2].set((PMTInterfaceOpeningX+2.0*mm)/2,UpperInterfacePlane+MiddleBoxHeight,(PMTInterfaceOpeningZ+2.0*mm)/2-QuartzToPMTOffsetInZ);
+  UpperConeBack[3].set(-(PMTInterfaceOpeningX+2.0*mm)/2,UpperInterfacePlane+MiddleBoxHeight,(PMTInterfaceOpeningZ+2.0*mm)/2-QuartzToPMTOffsetInZ);
+  UpperConeBack[4].set(-LowerIP_x,LowerInterfacePlane+MiddleBoxHeight,LowerIP_pz);
 
-  UpperConeSide1[0].set(LowerIP_x,LowerInterfacePlane,LowerIP_nz);
-  UpperConeSide1[1].set((PMTInterfaceOpeningX+2.0*mm)/2,UpperInterfacePlane,-(PMTInterfaceOpeningZ+2.0*mm)/2-QuartzToPMTOffsetInZ);
-  UpperConeSide1[2].set((PMTInterfaceOpeningX+2.0*mm)/2,UpperInterfacePlane,(PMTInterfaceOpeningZ+2.0*mm)/2-QuartzToPMTOffsetInZ);
-  UpperConeSide1[3].set(LowerIP_x,LowerInterfacePlane,LowerIP_pz);
-  UpperConeSide1[4].set(LowerIP_x,LowerInterfacePlane,LowerIP_nz);
+  UpperConeSide1[0].set(LowerIP_x,LowerInterfacePlane+MiddleBoxHeight,LowerIP_nz);
+  UpperConeSide1[1].set((PMTInterfaceOpeningX+2.0*mm)/2,UpperInterfacePlane+MiddleBoxHeight,-(PMTInterfaceOpeningZ+2.0*mm)/2-QuartzToPMTOffsetInZ);
+  UpperConeSide1[2].set((PMTInterfaceOpeningX+2.0*mm)/2,UpperInterfacePlane+MiddleBoxHeight,(PMTInterfaceOpeningZ+2.0*mm)/2-QuartzToPMTOffsetInZ);
+  UpperConeSide1[3].set(LowerIP_x,LowerInterfacePlane+MiddleBoxHeight,LowerIP_pz);
+  UpperConeSide1[4].set(LowerIP_x,LowerInterfacePlane+MiddleBoxHeight,LowerIP_nz);
 
-  UpperConeSide2[0].set(-LowerIP_x,LowerInterfacePlane,LowerIP_pz);
-  UpperConeSide2[1].set(-(PMTInterfaceOpeningX+2.0*mm)/2,UpperInterfacePlane,(PMTInterfaceOpeningZ+2.0*mm)/2-QuartzToPMTOffsetInZ);
-  UpperConeSide2[2].set(-(PMTInterfaceOpeningX+2.0*mm)/2,UpperInterfacePlane,-(PMTInterfaceOpeningZ+2.0*mm)/2-QuartzToPMTOffsetInZ);
-  UpperConeSide2[3].set(-LowerIP_x,LowerInterfacePlane,LowerIP_nz);
-  UpperConeSide2[4].set(-LowerIP_x,LowerInterfacePlane,LowerIP_pz);
+  UpperConeSide2[0].set(-LowerIP_x,LowerInterfacePlane+MiddleBoxHeight,LowerIP_pz);
+  UpperConeSide2[1].set(-(PMTInterfaceOpeningX+2.0*mm)/2,UpperInterfacePlane+MiddleBoxHeight,(PMTInterfaceOpeningZ+2.0*mm)/2-QuartzToPMTOffsetInZ);
+  UpperConeSide2[2].set(-(PMTInterfaceOpeningX+2.0*mm)/2,UpperInterfacePlane+MiddleBoxHeight,-(PMTInterfaceOpeningZ+2.0*mm)/2-QuartzToPMTOffsetInZ);
+  UpperConeSide2[3].set(-LowerIP_x,LowerInterfacePlane+MiddleBoxHeight,LowerIP_nz);
+  UpperConeSide2[4].set(-LowerIP_x,LowerInterfacePlane+MiddleBoxHeight,LowerIP_pz);
 
-  UpperConeTop[0].set((PMTInterfaceOpeningX+2.0*mm)/2,UpperInterfacePlane,-(PMTInterfaceOpeningZ+2.0*mm)/2-QuartzToPMTOffsetInZ);
-  UpperConeTop[1].set(-(PMTInterfaceOpeningX+2.0*mm)/2,UpperInterfacePlane,-(PMTInterfaceOpeningZ+2.0*mm)/2-QuartzToPMTOffsetInZ);
-  UpperConeTop[2].set(-(PMTInterfaceOpeningX+2.0*mm)/2,UpperInterfacePlane,(PMTInterfaceOpeningZ+2.0*mm)/2-QuartzToPMTOffsetInZ);
-  UpperConeTop[3].set((PMTInterfaceOpeningX+2.0*mm)/2,UpperInterfacePlane,(PMTInterfaceOpeningZ+2.0*mm)/2-QuartzToPMTOffsetInZ);
-  UpperConeTop[4].set((PMTInterfaceOpeningX+2.0*mm)/2,UpperInterfacePlane,-(PMTInterfaceOpeningZ+2.0*mm)/2-QuartzToPMTOffsetInZ);
+  UpperConeTop[0].set((PMTInterfaceOpeningX+2.0*mm)/2,UpperInterfacePlane+MiddleBoxHeight,-(PMTInterfaceOpeningZ+2.0*mm)/2-QuartzToPMTOffsetInZ);
+  UpperConeTop[1].set(-(PMTInterfaceOpeningX+2.0*mm)/2,UpperInterfacePlane+MiddleBoxHeight,-(PMTInterfaceOpeningZ+2.0*mm)/2-QuartzToPMTOffsetInZ);
+  UpperConeTop[2].set(-(PMTInterfaceOpeningX+2.0*mm)/2,UpperInterfacePlane+MiddleBoxHeight,(PMTInterfaceOpeningZ+2.0*mm)/2-QuartzToPMTOffsetInZ);
+  UpperConeTop[3].set((PMTInterfaceOpeningX+2.0*mm)/2,UpperInterfacePlane+MiddleBoxHeight,(PMTInterfaceOpeningZ+2.0*mm)/2-QuartzToPMTOffsetInZ);
+  UpperConeTop[4].set((PMTInterfaceOpeningX+2.0*mm)/2,UpperInterfacePlane+MiddleBoxHeight,-(PMTInterfaceOpeningZ+2.0*mm)/2-QuartzToPMTOffsetInZ);
 
   STLFile.open("LightGuideGeom.stl");
   STLFile << std::scientific;

--- a/src/MOLLEROptDetectorLightGuide.cc
+++ b/src/MOLLEROptDetectorLightGuide.cc
@@ -301,7 +301,7 @@ void MOLLEROptDetectorLightGuide::DefineGeometry()
   UpperConeVertices_out[6] = G4TwoVector(-(PMTInterfaceOpeningX+2.0*mm)/2,(PMTInterfaceOpeningZ+2.0*mm)/2-QuartzToPMTOffsetInZ);
   UpperConeVertices_out[7] = G4TwoVector((PMTInterfaceOpeningX+2.0*mm)/2,(PMTInterfaceOpeningZ+2.0*mm)/2-QuartzToPMTOffsetInZ);
 	
-  G4Box *GuideMiddleBoxSolid = new G4Box(thisName+"_InnerSolid",LowerIP_x,(LowerIP_pz-LowerIP_nz)/2,MiddleBoxHeight/2);	
+  G4Box *GuideMiddleBoxSolid_out = new G4Box(thisName+"_OuterSolid",LowerIP_x,(LowerIP_pz-LowerIP_nz)/2,MiddleBoxHeight/2);	
 
   //******************************************************************************************************************************
 

--- a/src/MOLLEROptDetectorLightGuide.cc
+++ b/src/MOLLEROptDetectorLightGuide.cc
@@ -9,10 +9,11 @@
              _____  PMT window _____   Upper Interface Plane
                   /           \
     upper cone   /             \ 
-           ____ /               \___   Lower Interface Plane
-                \               /
-    lower cone   \    .        /
-                  \   . .     /
+           _____/               \_____   Middle Interface Plane 
+ mid section    |		|
+           _____|               |_____   Lower Interface Plane 
+    lower cone   \        .    /
+                  \     . .   /
               _____\  .   .  /______  y = 0     
                       .   .
                       .   .
@@ -43,6 +44,7 @@ MOLLEROptDetectorLightGuide::MOLLEROptDetectorLightGuide(MOLLEROptTrackingReadou
   thisName = name+"_LG";
 
   LowerInterfacePlane     = 5.6*cm;
+  MiddleBoxHeight         = 10.0*cm
   UpperInterfacePlane     = 25.0*cm;
   LowerConeFrontFaceAngle = 28*TMath::Pi()/180*rad;                            
   LowerConeBackFaceAngle  =  22*TMath::Pi()/180*rad;
@@ -271,7 +273,7 @@ void MOLLEROptDetectorLightGuide::DefineGeometry()
   UpperConeVertices[6] = G4TwoVector(-PMTInterfaceOpeningX/2,PMTInterfaceOpeningZ/2-QuartzToPMTOffsetInZ);
   UpperConeVertices[7] = G4TwoVector(PMTInterfaceOpeningX/2,PMTInterfaceOpeningZ/2-QuartzToPMTOffsetInZ);  
 
-
+  G4Box *GuideMiddleBoxSolid = new G4Box(thisName+"_InnerSolid",LowerIP_x,(LowerIP_py-LowerIP_ny)/2,MiddleBoxHeight/2);
   
   //now do the outer surface ******************************************************************************************************
 
@@ -298,6 +300,8 @@ void MOLLEROptDetectorLightGuide::DefineGeometry()
   UpperConeVertices_out[5] = G4TwoVector(-(PMTInterfaceOpeningX+2.0*mm)/2,-(PMTInterfaceOpeningZ+2.0*mm)/2-QuartzToPMTOffsetInZ);
   UpperConeVertices_out[6] = G4TwoVector(-(PMTInterfaceOpeningX+2.0*mm)/2,(PMTInterfaceOpeningZ+2.0*mm)/2-QuartzToPMTOffsetInZ);
   UpperConeVertices_out[7] = G4TwoVector((PMTInterfaceOpeningX+2.0*mm)/2,(PMTInterfaceOpeningZ+2.0*mm)/2-QuartzToPMTOffsetInZ);
+	
+  G4Box *GuideMiddleBoxSolid = new G4Box(thisName+"_InnerSolid",LowerIP_x,(LowerIP_py-LowerIP_ny)/2,MiddleBoxHeight/2);	
 
   //******************************************************************************************************************************
 
@@ -313,13 +317,20 @@ void MOLLEROptDetectorLightGuide::DefineGeometry()
   
   
   G4RotationMatrix *rot = new G4RotationMatrix;
-  G4ThreeVector  trans = G4ThreeVector(0,0,UpperInterfacePlane/2);
-
   
+  //********************* Adding the box between the cones ************************************************************
+  
+  G4ThreeVector  trans = G4ThreeVector(0,LowerInterfacePlane*(TMath::Tan(LowerConeFrontFaceAngle) - TMath::Tan(LowerConeBackFaceAngle))/2,(LowerInterfacePlane+MiddleBoxHeight)/2);
+  
+  IntermediateInnerSolid = new G4UnionSolid(thisName+"_InnerSolid",LowerCone,GuideMiddleBoxSolid,rot,trans);
+  IntermediateOuterSolid = new G4UnionSolid(thisName+"_OuterSolid",LowerCone_out,GuideMiddleBoxSolid_out,rot,trans);
+  	
   //********************* Define the shell that is the guide **********************************************************
+	
+  trans = G4ThreeVector(0,0,UpperInterfacePlane/2 + MiddleBoxHeight); 
   
-  InnerSolid = new G4UnionSolid(thisName+"_InnerSolid",LowerCone,UpperCone,rot,trans);
-  OuterSolid = new G4UnionSolid(thisName+"_OuterSolid",LowerCone_out,UpperCone_out,rot,trans);
+  InnerSolid = new G4UnionSolid(thisName+"_InnerSolid",IntermediateInnerSolid,UpperCone,rot,trans);
+  OuterSolid = new G4UnionSolid(thisName+"_OuterSolid",IntermediateOuterSolid,UpperCone_out,rot,trans);
 
   G4SubtractionSolid *tempSolid = new G4SubtractionSolid(thisName+"_Temp_Solid",OuterSolid,InnerSolid);
   

--- a/src/MOLLEROptDetectorMessenger.cc
+++ b/src/MOLLEROptDetectorMessenger.cc
@@ -34,7 +34,13 @@ MOLLEROptDetectorMessenger::MOLLEROptDetectorMessenger(MOLLEROptDetector* theDet
   LightGuideUpperInterfaceCmd->SetGuidance("Set the light guide to PMT interface Y location.") ;         
   LightGuideUpperInterfaceCmd->SetParameterName("Size",true);                   
   LightGuideUpperInterfaceCmd->SetUnitCategory("Length");                       
-  LightGuideUpperInterfaceCmd->AvailableForStates(G4State_PreInit,G4State_Idle);                      
+  LightGuideUpperInterfaceCmd->AvailableForStates(G4State_PreInit,G4State_Idle);  
+  
+  LightGuideMiddleBoxCmd =  new G4UIcmdWithADoubleAndUnit("/Det/LightGuideMiddleBox",this); 
+  LightGuideMiddleBoxCmd->SetGuidance("Set the light guide straight middle box height.") ;         
+  LightGuideMiddleBoxCmd->SetParameterName("Size",true);                   
+  LightGuideMiddleBoxCmd->SetUnitCategory("Length");                       
+  LightGuideMiddleBoxCmd->AvailableForStates(G4State_PreInit,G4State_Idle); 
 
   LightGuideLowerInterfaceCmd =  new G4UIcmdWithADoubleAndUnit("/Det/LightGuideLowerInterface",this); 
   LightGuideLowerInterfaceCmd->SetGuidance("Set the light guide to Quartz interface Y location.") ;         
@@ -166,7 +172,8 @@ MOLLEROptDetectorMessenger::~MOLLEROptDetectorMessenger()
   if (DetYPositionCmd)      delete DetYPositionCmd;
   if (DetZPositionCmd)      delete DetZPositionCmd;
 
-  if(LightGuideUpperInterfaceCmd          ) delete LightGuideUpperInterfaceCmd;          
+  if(LightGuideUpperInterfaceCmd          ) delete LightGuideUpperInterfaceCmd; 
+  if(LightGuideMiddleBoxCmd               ) delete LightGuideMiddleBoxCmd; 
   if(LightGuideLowerInterfaceCmd          ) delete LightGuideLowerInterfaceCmd;          
   if(LightGuideLowerConeFrontAngleCmd     ) delete LightGuideLowerConeFrontAngleCmd;     
   if(LightGuideLowerConeBackAngleCmd      ) delete LightGuideLowerConeBackAngleCmd;      
@@ -202,6 +209,7 @@ void MOLLEROptDetectorMessenger::SetNewValue(G4UIcommand* command,G4String newVa
   if( command == DetMatCmd ) Det->SetMaterial(newValue);
 
   if( command == LightGuideUpperInterfaceCmd )         { Det->SetUpperInterfacePlane(LightGuideUpperInterfaceCmd->GetNewDoubleValue(newValue));}
+  if( command == LightGuideMiddleBoxCmd )              { Det->SetMiddleBoxHeight(LightGuideMiddleBoxCmd->GetNewDoubleValue(newValue));}
   if( command == LightGuideLowerInterfaceCmd )         { Det->SetLowerInterfacePlane(LightGuideLowerInterfaceCmd->GetNewDoubleValue(newValue));}
   if( command == LightGuideLowerConeFrontAngleCmd )    { Det->SetLowerConeFrontFaceAngle(LightGuideLowerConeFrontAngleCmd->GetNewDoubleValue(newValue));}
   if( command == LightGuideLowerConeBackAngleCmd )     { Det->SetLowerConeBackFaceAngle(LightGuideLowerConeBackAngleCmd->GetNewDoubleValue(newValue));}


### PR DESCRIPTION
Introduce a straight middle section in the lightguide in between upper and lower cone. Default set to 100mm but can be changed with messenger command `/Det/LightGuideMiddleBox`.